### PR TITLE
Make codepage for lua string settable ( default is UTF-8)

### DIFF
--- a/src/library/luacom.cpp
+++ b/src/library/luacom.cpp
@@ -198,7 +198,7 @@ static int luacom_ShowHelp(lua_State *L)
 
   Returns
     objeto luacom que encapsula objeto luacom implementado pela
-    tabela fornecida ou nil se nao for possível estabelecer a
+    tabela fornecida ou nil se nao for possÃ­vel estabelecer a
     conexao
     cookir do connection point
 
@@ -2126,6 +2126,16 @@ static int luacom_RoundTrip(lua_State *L) {
 }
 
 
+static int luacom_GetCodepage(lua_State *L) {
+  lua_pushnumber(L, code_page);  
+  return 1;  /* number of results */
+}
+
+// https://msdn.microsoft.com/de-de/library/windows/desktop/dd317756%28v=vs.85%29.aspx
+static int luacom_SetCodepage(lua_State *L) {
+  code_page=(UINT)luaL_checklong(L, 1);
+  return 0;
+}
 
 ///
 /// Table of functions exported by Lua.
@@ -2165,6 +2175,8 @@ static struct luaL_Reg functions_tb []=
   {"DetectAutomation", luacom_LuaDetectAutomation},
   {"StartMessageLoop", luacom_StartMessageLoop},
   {"RoundTrip", luacom_RoundTrip},
+  {"GetCodepage", luacom_GetCodepage},	// -hg 24.9.2015
+  {"SetCodepage", luacom_SetCodepage},  
   {NULL, NULL}
 };
   

--- a/src/library/tUtil.cpp
+++ b/src/library/tUtil.cpp
@@ -21,7 +21,7 @@ extern "C"
 
 #define MAX_VALID_STRING_SIZE 1000
 
-
+UINT code_page=CP_UTF8;		// Set UTF-8 as default code page
 FILE* tUtil::log_file = NULL;
 CRITICAL_SECTION log_file_cs;
 volatile bool g_log_file_cs_initialized = false;
@@ -108,7 +108,7 @@ tStringBuffer tUtil::bstr2string(BSTR bstr, bool nullTerminated)
 
       // gets string length
       int lenMulti = WideCharToMultiByte(
-        CP_UTF8,            // code page
+        code_page,            // code page
         0,            // performance and mapping flags
         bstr,    // wide-character string
         static_cast<int>(lenWide),  // number of chars in string
@@ -125,7 +125,7 @@ tStringBuffer tUtil::bstr2string(BSTR bstr, bool nullTerminated)
 		~C() { delete [] s; } char * s; } str(lenMulti + (nullTerminated? 1 : 0));
 
       int result = WideCharToMultiByte(
-        CP_UTF8,            // code page
+        code_page,            // code page
         0,            // performance and mapping flags
         bstr,    // wide-character string
         static_cast<int>(lenWide),  // number of chars in string
@@ -168,11 +168,11 @@ BSTR tUtil::string2bstr(const char * string, size_t len)
     {
       if (len != -1 && len > INT_MAX) LUACOM_ERROR("string too long");
       int lenWide =
-        MultiByteToWideChar(CP_UTF8, 0, string, static_cast<int>(len), NULL, 0);
+        MultiByteToWideChar(code_page, 0, string, static_cast<int>(len), NULL, 0);
       if(lenWide == 0)
         LUACOM_ERROR(tUtil::GetErrorMessage(GetLastError()));
       bstr = SysAllocStringLen(NULL, lenWide); // plus initializes '\0' terminator
-      MultiByteToWideChar(  CP_UTF8, 0, string, static_cast<int>(len), bstr, lenWide);
+      MultiByteToWideChar(  code_page, 0, string, static_cast<int>(len), bstr, lenWide);
     }
     return bstr;
   }

--- a/src/library/tUtil.h
+++ b/src/library/tUtil.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include "tStringBuffer.h"  // Added by ClassView
 
+extern UINT code_page;		// can be set by Lua
 struct lua_State;
 class tUtil  
 {


### PR DESCRIPTION
I need all strings out of a COM object encoded in CP_1250. Stock luacom does UTF-8 on all conversions - which is of course best for most scenarios.
Now you have the choice :-)
